### PR TITLE
Add missing prefix on variable type

### DIFF
--- a/lib/templates.rb
+++ b/lib/templates.rb
@@ -92,7 +92,7 @@ module GV_FSM
       <% end %>
 
       // state manager
-      <%= @prefix %>state_t <%= @prefix %>run_state(<%= @prefix %>state_t cur_state, state_data_t *data);
+      <%= @prefix %>state_t <%= @prefix %>run_state(<%= @prefix %>state_t cur_state, <%= @prefix %>state_data_t *data);
       
       <% if !@ino then %>
       #endif


### PR DESCRIPTION
Add [missing prefix](https://www.youtube.com/watch?v=dQw4w9WgXcQ)